### PR TITLE
Bump version to 1.4.3 for next development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.3
+
+_(Development version - no changes yet)_
+
 ## 1.4.2
 
 - Fix blurry now-playing artwork thumbnails by requesting higher-resolution images from Apple TV

--- a/project.yml
+++ b/project.yml
@@ -72,7 +72,7 @@ targets:
         PRODUCT_NAME: Itsytv
         GENERATE_INFOPLIST_FILE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: "1.4.2"
+        MARKETING_VERSION: "1.4.3"
         CURRENT_PROJECT_VERSION: "15"
         ENABLE_HARDENED_RUNTIME: true
       configs:


### PR DESCRIPTION
Automated version bump after v1.4.2 release.

This PR prepares the repository for the next development cycle by bumping the version to 1.4.3.