### PR TITLE
Add AppleScript play and pause verbs

### DIFF
--- a/itsytv/Info.plist
+++ b/itsytv/Info.plist
@@ -24,6 +24,8 @@
 	<string>public.app-category.entertainment</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSAppleScriptEnabled</key>
+	<true/>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>itsytv needs local network access to discover and control Apple TV devices on your network.</string>
 	<key>NSBonjourServices</key>
@@ -31,5 +33,7 @@
 		<string>_companion-link._tcp</string>
 		<string>_mediaremotetv._tcp</string>
 	</array>
+	<key>OSAScriptingDefinition</key>
+	<string>itsytv.sdef</string>
 </dict>
 </plist>

--- a/itsytv/Utilities/ScriptCommands.swift
+++ b/itsytv/Utilities/ScriptCommands.swift
@@ -1,0 +1,40 @@
+import AppKit
+import os.log
+import ItsytvCore
+
+private let log = Logger(subsystem: "com.itsytv.app", category: "Script")
+
+// Permissive on unknown state: only skip when we *know* the TV is already
+// in the requested state. nowPlaying = nil (no MRP update yet on this
+// session) means we forward the command — MRP .pause / .play is a safe
+// no-op TV-side when nothing is loaded.
+
+@objc(ITSPauseScriptCommand)
+final class PauseScriptCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        Task { @MainActor in
+            guard let manager = AppDelegate.shared?.manager else {
+                log.error("pause: AppDelegate.shared not available")
+                return
+            }
+            if let np = manager.mrpManager.nowPlaying, !np.isPlaying { return }
+            manager.mrpManager.sendCommand(.pause)
+        }
+        return nil
+    }
+}
+
+@objc(ITSPlayScriptCommand)
+final class PlayScriptCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        Task { @MainActor in
+            guard let manager = AppDelegate.shared?.manager else {
+                log.error("play: AppDelegate.shared not available")
+                return
+            }
+            if let np = manager.mrpManager.nowPlaying, np.isPlaying { return }
+            manager.mrpManager.sendCommand(.play)
+        }
+        return nil
+    }
+}

--- a/itsytv/itsytv.sdef
+++ b/itsytv/itsytv.sdef
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dictionary SYSTEM "file://localhost/System/Library/DTDs/sdef.dtd">
+<dictionary title="itsytv Terminology">
+    <suite name="itsytv Suite" code="iTSv" description="Control the connected Apple TV.">
+        <command name="pause" code="iTSvpaus"
+                 description="Pause playback on the connected Apple TV. No-op if nothing is currently playing.">
+            <cocoa class="ITSPauseScriptCommand"/>
+        </command>
+        <command name="play" code="iTSvplay"
+                 description="Resume playback on the connected Apple TV. No-op if nothing is loaded or it is already playing.">
+            <cocoa class="ITSPlayScriptCommand"/>
+        </command>
+    </suite>
+</dictionary>


### PR DESCRIPTION
Closes #48.

Adds two AppleScript verbs in a new `itsytv` suite:

- `play` — sends MRP `MediaCommand.play`. Skips the send if `mrpManager.nowPlaying.isPlaying == true`.
- `pause` — sends MRP `MediaCommand.pause`. Skips the send if `mrpManager.nowPlaying.isPlaying == false`.

Permissive on unknown state: if `mrpManager.nowPlaying` is `nil` (no MRP update yet on this session), the command is forwarded — MRP `.play` / `.pause` is a safe no-op TV-side when nothing is loaded.

Usage from the command line / Hammerspoon / Keyboard Maestro / Shortcuts:

```sh
osascript -e 'tell application "Itsytv" to pause'
osascript -e 'tell application "Itsytv" to play'
```

## Files

- `itsytv/itsytv.sdef` — scripting dictionary, suite code `iTSv`, command codes `iTSvpaus` / `iTSvplay`.
- `itsytv/Utilities/ScriptCommands.swift` — `NSScriptCommand` subclasses (`ITSPauseScriptCommand`, `ITSPlayScriptCommand`) wired to `AppDelegate.shared?.manager.mrpManager`.
- `itsytv/Info.plist` — adds `NSAppleScriptEnabled = true` and `OSAScriptingDefinition = itsytv.sdef`.

## Sandbox / entitlements

No entitlement changes. A sandboxed app *receiving* Apple events does not require any additional entitlements — only senders do (`com.apple.security.automation.apple-events`, granted by the user via TCC). The change works identically for both the App Store target and the direct-distribution target.

## Verification

```sh
xcodebuild -project itsytv.xcodeproj -scheme itsytv -configuration Debug -destination 'generic/platform=macOS' build
```

Confirmed locally:
- `Itsytv.app/Contents/Resources/itsytv.sdef` is bundled.
- `Itsytv.app/Contents/Info.plist` has both new keys.
- Bundle compiles clean against the existing `ItsytvCore` `mrpManager` API; no upstream changes required.

## Notes

- Verbs intentionally do not duplicate the existing HID `play/pause` toggle. The whole point is that they are idempotent and safe to fire from any "everything quiet" automation, where a toggle would resume playback on a quiet TV.
- First invocation will trigger a standard macOS Automation prompt for the *sender* app to control Itsytv (not for Itsytv itself).